### PR TITLE
A dirty re-implementation of mining wallet address autodetection

### DIFF
--- a/stratum/coinbase.cpp
+++ b/stratum/coinbase.cpp
@@ -118,8 +118,10 @@ void coinbase_aux(YAAMP_JOB_TEMPLATE *templ, char *aux_script)
 
 void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *json_result)
 {
+	//================= Alien coins/algos/encodings
+
 	templ->isbitcash = false;
-	if(strcmp(coind->symbol, "BITC") == 0) 
+	if(!strcmp(coind->symbol, "BITC")) 
 	{
 		char *params = (char *)malloc(4096);
 		if (params) {
@@ -161,12 +163,10 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		}
 		return;
 	}
-	
+
 	char eheight[32], etime[32];
 	char entime[32] = { 0 };
 	char commitment[128] = { 0 };
-
-	bool is_equihash = (strstr(g_current_algo->name, "equihash") == g_current_algo->name);
 
 	ser_number(templ->height, eheight);
 	ser_number(time(NULL), etime);
@@ -177,45 +177,23 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		strcpy(eversion1, "02000000");
 
 	const char *coinbase_payload = json_get_string(json_result, "coinbase_payload");
+
 	if(coinbase_payload && strlen(coinbase_payload) > 0)
 		strcpy(eversion1, "03000500");
 
 	char script1[4*1024];
 	sprintf(script1, "%s%s%s08", eheight, templ->flags, etime);
 
-	char script2[32] = "506f6f6c4d696e652e78797a"; // "yiimp\0" in hex ascii
-
-	// init saplingroothash for equihash
-	templ->saplingroothash[0] =0;
-
-	int n = templ->height; int s;
-	for(int i=0; i<32; i++) {
-		char tmp[32];
-		s = n % 256; n /= 256;
-		sprintf(tmp, "%02x", s);
-		strcat(templ->saplingroothash, tmp);
-	}
-	string_be1(templ->saplingroothash);
-
-	// reset coinbase-string
-	templ->coinbase[0] = 0;
+	char script2[32] = "7969696d7000"; // "yiimp\0" in hex ascii //"506f6f6c4d696e652e78797a" -- PoolMine.xyz
 
 	if(!coind->pos && !coind->isaux && templ->auxs_size)
 		coinbase_aux(templ, script2);
 
 	int script_len = strlen(script1)/2 + strlen(script2)/2 + 8;
-	if(!strcmp(g_stratum_algo,"neoscrypt-xaya")) script_len = script_len - 8;
-
+	if(!strcmp(g_stratum_algo,"neoscrypt-xaya")) script_len -= 8;
 	sprintf(templ->coinb1, "%s%s01"
 		"0000000000000000000000000000000000000000000000000000000000000000"
 		"ffffffff%02x%s", eversion1, entime, script_len, script1);
-	
-	if (coind->p2wpkh) {
-		sprintf(templ->coinb1_p2wpkh, "%s%s%s01"
-			"0000000000000000000000000000000000000000000000000000000000000000"
-			"ffffffff%02x%s", eversion1, entime, "0001", script_len, script1);
-		templ->is_p2wpkh = true;
-	}
 
 	sprintf(templ->coinb2, "%s00000000", script2);
 
@@ -225,19 +203,34 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 
 	json_int_t available = templ->value;
 
-	if (strcmp(coind->rpcencoding, "ZEC") == 0)	{
+	//================= Semi-alien coins/algos/encodings go below. Synax hasn't changed. End 'em with 'return'. For btc forks use it for the wildest of coin devs' fantasies - I've left some examples.
+
+	if (!strcmp(coind->rpcencoding, "ZEC")) {
+	// init saplingroothash for equihash
+		templ->saplingroothash[0] = 0;
+
+		int n = templ->height; int s;
+		for(int i=0; i<32; i++) {
+			char tmp[32];
+			s = n % 256; n /= 256;
+			sprintf(tmp, "%02x", s);
+			strcat(templ->saplingroothash, tmp);
+		}
+		string_be1(templ->saplingroothash);
+
 		char eversion3[64] = "0400008085202f89";
 
 		sprintf(script1, "%s%s%s00", eheight, templ->flags, etime);
 		// nonce not included , set length to 0
 
 		// Pool identstring in coinbase-TX
-		sprintf(script2,"506f6f6c4d696e652e78797a00"); // "yiimp\0" in hex ascii
+		sprintf(script2,"7969696d7000"); // "yiimp\0" in hex ascii //"506f6f6c4d696e652e78797a" -- PoolMine.xyz
 
 		if(!coind->pos && !coind->isaux && templ->auxs_size)
 			coinbase_aux(templ, script2);
 
 		// nonce not included in coinbase of equihash-coins
+		bool is_equihash = (strstr(g_current_algo->name, "equihash") == g_current_algo->name);
 		int script_len = strlen(script1)/2 + strlen(script2)/2 + (is_equihash?0:8);
 		sprintf(templ->coinb1, "%s%s01"
 			"0000000000000000000000000000000000000000000000000000000000000000"
@@ -262,7 +255,7 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		if (template_coinbase) {
 			const char *coinbasetxn_data = json_get_string(template_coinbase, "data");
 			sprintf(templ->coinbase, "%s", coinbasetxn_data);
-//			debuglog("coinbase %s\n",templ->coinbase);
+			//debuglog("coinbase %s\n",templ->coinbase);
 		}
 
 		// temp. analyze template without creating coinbase tx - using precreated tx
@@ -280,1166 +273,83 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		return;
 	}
 
+	if(!strcmp(g_stratum_algo,"neoscrypt-xaya")) {
+       	sprintf(templ->xaya_coinbase, "%s%s", templ->coinb1, templ->coinb2);
+
+		int coinbase_len = strlen(templ->xaya_coinbase);
+
+		unsigned char coinbase_bin[1024];
+		memset(coinbase_bin, 0, 1024);
+		binlify(coinbase_bin, templ->xaya_coinbase);
+
+		char doublehash[128];
+		memset(doublehash, 0, 128);
+
+		sha256_double_hash_hex((char *)coinbase_bin, doublehash, coinbase_len/2);
+
+		string merkleroot = merkle_with_first(templ->txsteps, doublehash);
+
+		ser_string_be(merkleroot.c_str(), templ->xaya_merkleroothash, 8);
+
+		char prevhash[128];
+		memset(prevhash, 0, 128);
+
+		string_be(templ->prevhash_hex, prevhash);
+		ser_string_be(prevhash, templ->prevhash_be, 8);
+
+		char xaya_header[1024];
+		memset(xaya_header, 0, 1024);
+
+		sprintf(xaya_header, "%s%s%s%s", templ->version, templ->prevhash_be, templ->xaya_merkleroothash, templ->ntime);
+
+		ser_string_be(xaya_header, templ->xaya_header, 20);
+		strcat(templ->xaya_header, "0000");
+		return;
+	}
+
 	// sample coins using mandatory dev/foundation fees
-	if(strcmp(coind->symbol, "EGC") == 0) {
+	if (!strcmp(coind->symbol, "EGC")) //hardcoded everything
+	{
 		if (coind->charity_percent <= 0)
 			coind->charity_percent = 2;
 		if (strlen(coind->charity_address) == 0)
 			sprintf(coind->charity_address, "EdFwYw4Mo2Zq6CFM2yNJgXvE2DTJxgdBRX");
 	}
-	else if(strcmp(coind->symbol, "DYN") == 0)
+
+	else if(!strcmp(coind->symbol, "LTCR")) //hardcoded everything
 	{
-		char script_dests[2048] = { 0 };
-		char script_payee[128] = { 0 };
-		char payees[3];
-		int npayees = (templ->has_segwit_txs) ? 2 : 1;
-		bool dynode_enabled;
-		dynode_enabled = json_get_bool(json_result, "dynode_payments_enforced");
-		bool superblocks_enabled = json_get_bool(json_result, "superblocks_enabled");
-		json_value* superblock = json_get_array(json_result, "superblock");
-		json_value* dynode;
-		dynode = json_get_object(json_result, "dynode");
-		if(!dynode && json_get_bool(json_result, "dynode_payments")) {
-			coind->oldmasternodes = true;
-			debuglog("%s is using old dynodes rpc keys\n", coind->symbol);
-			return;
-		}
+		if (coind->charity_percent <= 0)
+			coind->charity_percent = 10;
+		if (strlen(coind->charity_address) == 0)
+			sprintf(coind->charity_address, "BCDrF1hWdKTmrjXXVFTezPjKBmGigmaXg5");
+	}
 
-		if(superblocks_enabled && superblock) {
-			for(int i = 0; i < superblock->u.array.length; i++) {
-				const char *payee = json_get_string(superblock->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(superblock->u.array.values[i], "amount");
-				if (payee && amount) {
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-					//debuglog("%s superblock found %s %u\n", coind->symbol, payee, amount);
-				}
-			}
-		}
-		if (dynode_enabled && dynode) {
-			bool started;
-			started = json_get_bool(json_result, "dynode_payments_started");
-			const char *payee = json_get_string(dynode, "payee");
-			json_int_t amount = json_get_int(dynode, "amount");
-			if (!payee)
-				debuglog("coinbase_create failed to get Dynode payee\n");
-
-			if (!amount)
-				debuglog("coinbase_create failed to get Dynode amount\n");
-
-			if (!started)
-				debuglog("coinbase_create failed to get Dynode started\n");
-
-			if (payee && amount && started) {
-				npayees++;
-				available -= amount;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
-				//debuglog("%s dynode found %s %u\n", coind->symbol, payee, amount);
-			}
-		}
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		if (templ->has_segwit_txs) strcat(templ->coinb2, commitment);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		coind->reward = (double)available/100000000*coind->reward_mul;
-		//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
+	/* else if(!strcmp("DCR", coind->rpcencoding)) //afaik this doen't work any more, left for history
+	{
+		coind->reward_mul = 6;  // coinbase value is wrong, reward_mul should be 6
+		coind->charity_percent = 0;
+		coind->charity_amount = available;
+		available *= coind->reward_mul;
+		if (strlen(coind->charity_address) == 0 && !strcmp(coind->symbol, "DCR"))
+			sprintf(coind->charity_address, "Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx");
+	}
+	if(coind->charity_amount && !strcmp("DCR", coind->rpcencoding))	{
+		stratumlog("ERROR %s should not use coinbase (getwork only)!\n", coind->symbol);
+		coind->reward = (double)available/100000000;
 		return;
-	}
+	}*/
 
-    else if(strcmp(coind->symbol, "KCN") == 0) 
-	{
-		char outputs_count[4] = { 0 };
-        char devscript2[256] = { 0 };
-        char devscript_len[3] = { 0 };
-        unsigned int outputs = 2;
-        char dev_amount[32];
-        json_value *devreward = json_get_object(json_result, "coinbasedevreward");
-        json_int_t devvalue = json_get_int(devreward, "value");
-        const char *devscript = json_get_string(devreward, "scriptpubkey");
-        encode_tx_value(dev_amount, devvalue);
-        snprintf(devscript2, 255, "%s", devscript);
-        sprintf(devscript_len, "%02x", strlen(devscript2) >> 1);
-        if (templ->has_segwit_txs) outputs++;
-        sprintf(outputs_count, "%02x", outputs);
-        strcat(templ->coinb2, outputs_count);
-        job_pack_tx(coind, templ->coinb2, available, NULL);
-        coind->reward = (double)available/100000000*coind->reward_mul;
-        strcat(templ->coinb2, dev_amount);
-        strcat(templ->coinb2, devscript_len);
-        strcat(templ->coinb2, devscript2);
-        if (templ->has_segwit_txs) strcat(templ->coinb2, commitment);
-        strcat(templ->coinb2, "00000000");
-        return;
-    }
-
-	else if(strcmp(coind->symbol, "VGC") == 0)
-	{
-		char script_dests[2048] = { 0 };
-		char script_payee[128] = { 0 };
-		char payees[3];
-		int npayees = (templ->has_segwit_txs) ? 2 : 1;
-		json_value* fivegnode;
-		fivegnode = json_get_object(json_result, "fivegnode");
-		if(!fivegnode && json_get_bool(json_result, "fivegnode_payments")) {
-			coind->oldmasternodes = true;
-			debuglog("%s is using old indexnodes rpc keys\n", coind->symbol);
-			return;
-		}
-		if (fivegnode) {
-			bool started;
-			started = json_get_bool(json_result, "fivegnode_payments_started");
-			const char *payee = json_get_string(fivegnode, "payee");
-			json_int_t amount = json_get_int(fivegnode, "amount");
-			if (!payee)
-				debuglog("coinbase_create failed to get Fivegnode payee\n");
-
-			if (!amount)
-				debuglog("coinbase_create failed to get Fivegnode amount\n");
-
-			if (!started)
-				debuglog("coinbase_create failed to get Fivegnode started\n");
-
-			if (payee && amount && started) {
-				npayees++;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
-				debuglog("%s fivegnode found %s %u\n", coind->symbol, payee, amount);
-			}
-		}
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		if (templ->has_segwit_txs) strcat(templ->coinb2, commitment);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		coind->reward = (double)available/100000000*coind->reward_mul;
-		//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
-		return;
-	}
-
-
-			else if(strcmp(coind->symbol, "BBC") == 0)
-	{
-			char payees[4];
-			int npayees = 1;
-			char script_dests[4096] = { 0 };
-
-			json_value* smartnode = json_get_object(json_result, "smartnode");
-			debuglog("BBC DETECTED Json: RESULT %s\n", smartnode);
-			bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-			if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-			{
-				const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-				if (payee && amount) 
-				{
-					char script_payee[128] = { 0 };
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-				debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) 
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "GSPC") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-
-		json_value* smartnode = json_get_object(json_result, "smartnode");
-		//debuglog("GSPC DETECTED Json: RESULT %s\n", smartnode);
-		bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-		if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-			{
-				const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-				if (payee && amount) 
-				{
-					char script_payee[128] = { 0 };
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-				//debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			//debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) 
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-	
-	else if(strcmp(coind->symbol, "YERB") == 0)
-	{
-			char payees[4];
-			int npayees = 1;
-			char script_dests[4096] = { 0 };
-
-			json_value* smartnode = json_get_object(json_result, "smartnode");
-			bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-			if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-			{
-				const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-				if (payee && amount) 
-				{
-					char script_payee[128] = { 0 };
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-				debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) 
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "FUEC") == 0)
-	{
-			char payees[4];
-			int npayees = 1;
-			char script_dests[4096] = { 0 };
-
-			json_value* smartnode = json_get_object(json_result, "smartnode");
-			bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-			if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-			{
-				const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-				if (payee && amount)
-				{
-					char script_payee[128] = { 0 };
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-				debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			//debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0)
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "NAPI") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-
-		json_value* smartnode = json_get_object(json_result, "smartnode");
-		bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-		if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-			{
-				const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-				if (payee && amount) 
-				{
-					char script_payee[128] = { 0 };
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-		}
-
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) 
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-		else if(strcmp(coind->symbol, "THOON") == 0)
-	{
-			char payees[4];
-			int npayees = 1;
-			char script_dests[4096] = { 0 };
-
-			json_value* smartnode = json_get_object(json_result, "smartnode");
-			bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-			if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-			{
-				const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-				if (payee && amount) 
-				{
-					char script_payee[128] = { 0 };
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-				debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) 
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-	
-		else if(strcmp(coind->symbol, "JGC") == 0)
-	{
-			char payees[4];
-			int npayees = 1;
-			char script_dests[4096] = { 0 };
-
-			json_value* smartnode = json_get_object(json_result, "smartnode");
-			bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-			if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-			{
-				const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-				if (payee && amount) 
-				{
-					char script_payee[128] = { 0 };
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-				debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) 
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-	
-	else if(strcmp(coind->symbol, "BTRM") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-
- 		json_value* smartnode = json_get_object(json_result, "smartnode");
-		bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-		if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-                        {
-			const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-			json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-			if (payee && amount) {
-				char script_payee[128] = { 0 };
-				npayees++;
-				available -= amount;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
-			}
-			debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-
-	 	sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) {
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "LTRM") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-
- 		json_value* smartnode = json_get_object(json_result, "smartnode");
-		bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-		if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-                        {
-			const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-			json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-			if (payee && amount) {
-				char script_payee[128] = { 0 };
-				npayees++;
-				available -= amount;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
-			}
-			debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-
-	 	sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) {
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "BTSC") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-
- 		json_value* smartnode = json_get_object(json_result, "smartnode");
-		bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-		if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-                        {
-			const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-			json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-			if (payee && amount) {
-				char script_payee[128] = { 0 };
-				npayees++;
-				available -= amount;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
-			}
-			debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-
-	 	sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) {
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "RTM") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-
- 		json_value* smartnode = json_get_object(json_result, "smartnode");
-		bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-		if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-                        {
-			const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-			json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-			if (payee && amount) {
-				char script_payee[128] = { 0 };
-				npayees++;
-				available -= amount;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
-			}
-			debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-	
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-	
-	 	sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) {
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "FITA") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-
- 		json_value* smartnode = json_get_object(json_result, "smartnode");
-		bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-		if (smartnode_started && smartnode)
-		{
-			for(int i = 0; i < smartnode->u.array.length; i++)
-                        {
-			const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-			json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-			if (payee && amount) {
-				char script_payee[128] = { 0 };
-				npayees++;
-				available -= amount;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
-			}
-			debuglog("SMARTNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-	
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-			debuglog("FOUNDER DETECTED Payee: %s\n", founder_payee);
-		}
-	
-	 	sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) {
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	if(strcmp(coind->symbol, "FROG") == 0) 
-	{
-		// make sure we pay both mn and devops
-                bool founder_enabled = json_get_bool(json_result, "enforce_devops_payments");
-                bool masternode_enabled = json_get_bool(json_result, "enforce_masternode_payments");
-                if (!founder_enabled || !masternode_enabled)
-                        return;
-
-                // founder/masternode vars
-                char founder_script[1024] = { 0 };
-                char masternode_script[1024] = { 0 };
-                char founder_payee[256] = { 0 };
-                char masternode_payee[256] = { 0 };
-                json_int_t dev_amount = json_get_int(json_result, "devops_amount");
-                json_int_t pool_amount = json_get_int(json_result, "coinbasevalue");
-                json_int_t mn_amount = json_get_int(json_result, "payee_amount");
-                const char *payee1 = json_get_string(json_result, "masternode_payee");
-                const char *payee2 = json_get_string(json_result, "devops_payee");
-
-                // mn script
-                snprintf(masternode_payee, 255, "%s", payee1);
-                base58_decode(masternode_payee, masternode_script);
-                //available -= part_amount;
-
-                // payee script
-                snprintf(founder_payee, 255, "%s", payee2);
-                base58_decode(founder_payee, founder_script);
-                //available -= part_amount;
-
-                // total outputs
-                strcat(templ->coinb2, "03");
-
-                // pack the tx
-                job_pack_tx(coind, templ->coinb2, available, NULL);
-                job_pack_tx(coind, templ->coinb2, mn_amount, masternode_script);
-                job_pack_tx(coind, templ->coinb2, dev_amount, founder_script);
-                strcat(templ->coinb2, "00000000");
-                coind->reward = (double)available / 100000000 * coind->reward_mul;
-                return;
-	}
-
-	else if(strcmp(coind->symbol, "WATC") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_payee[128] = { 0 };
-		char script_dests[4096] = { 0 };
-	
- 		json_value* smartnode = json_get_object(json_result, "smartnode");
-		bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-		if (smartnode_started && smartnode)
-		{
-			if (json_is_array(smartnode)) 
-			{
-				for(int i = 0; i < smartnode->u.array.length; i++) 
-				{
-					const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-					const char *script = json_get_string(smartnode->u.array.values[i], "script");
-					json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-					if (!amount) continue;
-					if (script) 
-					{
-						npayees++;
-						available -= amount;
-						script_pack_tx(coind, script_dests, amount, script);
-					} 
-					else if (payee) 
-					{
-						npayees++;
-						available -= amount;
-						base58_decode(payee, script_payee);
-						job_pack_tx(coind, script_dests, amount, script_payee);
-						//debuglog("%s smartnode %s %u\n", coind->symbol, payee, amount);
-					}
-				}
-			} 
-			else 
-			{
-				const char *payee = json_get_string(smartnode, "payee");
-				json_int_t amount = json_get_int(smartnode, "amount");
-				if (payee && amount) 
-				{
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-			}
-		}
-	
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				char founder_script_payee[128] = { 0 };
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-		}
-	
-	 	sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) {
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "BUTK") == 0 || strcmp(coind->symbol2, "BUTK") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-		char script_payee[128] = { 0 };
-		char founder_script_payee[128] = { 0 };
-					
- 		json_value* smartnode = json_get_object(json_result, "smartnode");
-		bool smartnode_started = json_get_bool(json_result, "smartnode_payments_started");
-		if (smartnode_started && smartnode)
-		{
-			if (json_is_array(smartnode)) 
-			{
-				for(int i = 0; i < smartnode->u.array.length; i++) 
-				{
-					const char *payee = json_get_string(smartnode->u.array.values[i], "payee");
-					const char *script = json_get_string(smartnode->u.array.values[i], "script");
-					json_int_t amount = json_get_int(smartnode->u.array.values[i], "amount");
-					if (!amount) continue;
-					if (script) 
-					{
-						npayees++;
-						available -= amount;
-						script_pack_tx(coind, script_dests, amount, script);
-					} 
-					else if (payee) 
-					{
-						npayees++;
-						available -= amount;
-						base58_decode(payee, script_payee);
-						job_pack_tx(coind, script_dests, amount, script_payee);
-						//debuglog("%s smartnode %s %u\n", coind->symbol, payee, amount);
-					}
-				}
-			} 
-			else 
-			{
-				const char *payee = json_get_string(smartnode, "payee");
-				json_int_t amount = json_get_int(smartnode, "amount");
-				if (payee && amount) 
-				{
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-			}
-		}
-	
-		json_value* founder = json_get_array(json_result, "founder");
-		bool founder_payments_started = json_get_bool(json_result, "founder_payments_started");
-		if (founder_payments_started && founder)
-		{
-			const char *founder_payee = json_get_string(founder, "payee");
-			json_int_t founder_amount = json_get_int(founder, "amount");
-			if (founder_payee && founder_amount)
-			{
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-		}
-	
-	 	sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) 
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "VKAX") == 0)
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-
-		json_value* masternode = json_get_object(json_result, "masternode");
-		debuglog("VKAX DETECTED Json: RESULT %s\n", masternode);
-		bool masternode_started = json_get_bool(json_result, "masternode_payments_started");
-		if (masternode_started && masternode)
-		{
-			for(int i = 0; i < masternode->u.array.length; i++)
-			{
-				const char *payee = json_get_string(masternode->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(masternode->u.array.values[i], "amount");
-				if (payee && amount) 
-				{
-					char script_payee[128] = { 0 };
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-				debuglog("MASTERNODE DETECTED Payee: %s\n", payee);
-			}
-		}
-
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) 
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-	
-	else if(strcmp(coind->symbol, "IDX") == 0)
-	{
-		char script_dests[2048] = { 0 };
-		char script_payee[128] = { 0 };
-		char payees[3];
-		int npayees = (templ->has_segwit_txs) ? 2 : 1;
-		json_value* indexnode;
-		indexnode = json_get_object(json_result, "indexnode");
-		if(!indexnode && json_get_bool(json_result, "indexnode_payments")) {
-			coind->oldmasternodes = true;
-			debuglog("%s is using old indexnodes rpc keys\n", coind->symbol);
-			return;
-		}
-		if (indexnode) {
-			bool started;
-			started = json_get_bool(json_result, "indexnode_payments_started");
-			const char *payee = json_get_string(indexnode, "payee");
-			json_int_t amount = json_get_int(indexnode, "amount");
-			if (!payee)
-				debuglog("coinbase_create failed to get Indexnode payee\n");
-
-			if (!amount)
-				debuglog("coinbase_create failed to get Indexnode amount\n");
-
-			if (!started)
-				debuglog("coinbase_create failed to get Indexnode started\n");
-
-			if (payee && amount && started) {
-				npayees++;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
-				//debuglog("%s indexnode found %s %u\n", coind->symbol, payee, amount);
-			}
-		}
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		if (templ->has_segwit_txs) strcat(templ->coinb2, commitment);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		coind->reward = (double)available/100000000*coind->reward_mul;
-		//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
-		return;
-	}
-
-
-	else if(strcmp(coind->symbol, "GXX") == 0) 
+	else if(!strcmp(coind->symbol, "GXX")) //hardcoded everything
 	{
 		char script_payee[1024];
 		bool znode_masternode_enabled = json_get_bool(json_result, "xnode_payments_started");
 		
-		if (znode_masternode_enabled == true) 
-		{
+		if (znode_masternode_enabled == true) {
 			json_value* znode_masternode = json_get_object(json_result, "xnode");
 			const char *payee = json_get_string(znode_masternode, "payee");
 			json_int_t amount = json_get_int(znode_masternode, "amount");
 			
-			if (payee && amount) 
-			{
+			if (payee && amount) {
 				//debuglog("xnode payee: %s\n", payee);
 				strcat(templ->coinb2, "04");
 				job_pack_tx(coind, templ->coinb2, available, NULL);
@@ -1448,8 +358,7 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 				job_pack_tx(coind, templ->coinb2, amount, script_payee);
 			}
 		} 
-		else 
-		{
+		else {
 			strcat(templ->coinb2, "03");
 			job_pack_tx(coind, templ->coinb2, available, NULL);
 		}
@@ -1466,16 +375,10 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		return;
 	}
 
-	else if(strcmp(coind->symbol, "LTCR") == 0) {
-		if (coind->charity_percent <= 0)
-			coind->charity_percent = 10;
-		if (strlen(coind->charity_address) == 0)
-			sprintf(coind->charity_address, "BCDrF1hWdKTmrjXXVFTezPjKBmGigmaXg5");
-	}
-
-	else if(strcmp(coind->symbol, "XZC") == 0) {
+	else if(!strcmp(coind->symbol, "XZC")) //hardcoded everything
+	{
         char script_payee[1024];
-         bool znode_masternode_enabled = json_get_bool(json_result, "znode_payments_started");
+        bool znode_masternode_enabled = json_get_bool(json_result, "znode_payments_started");
         if (znode_masternode_enabled == true) {
             json_value* znode_masternode = json_get_object(json_result, "znode");
             const char *payee = json_get_string(znode_masternode, "payee");
@@ -1484,118 +387,90 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
                 //debuglog("znode payee: %s\n", payee);
                 strcat(templ->coinb2, "06");
                 job_pack_tx(coind, templ->coinb2, available, NULL);
-                 base58_decode(payee, script_payee);
+                base58_decode(payee, script_payee);
                 job_pack_tx(coind, templ->coinb2, amount, script_payee);
             }
         } else {
             strcat(templ->coinb2, "06");
             job_pack_tx(coind, templ->coinb2, available, NULL);
         }
-         base58_decode("aCAgTPgtYcA4EysU4UKC86EQd5cTtHtCcr", script_payee);
+        base58_decode("aCAgTPgtYcA4EysU4UKC86EQd5cTtHtCcr", script_payee);
         job_pack_tx(coind, templ->coinb2, 1 * 100000000, script_payee);
-         base58_decode("aHu897ivzmeFuLNB6956X6gyGeVNHUBRgD", script_payee);
+        base58_decode("aHu897ivzmeFuLNB6956X6gyGeVNHUBRgD", script_payee);
         job_pack_tx(coind, templ->coinb2, 1 * 100000000, script_payee);
-         base58_decode("aQ18FBVFtnueucZKeVg4srhmzbpAeb1KoN", script_payee);
+        base58_decode("aQ18FBVFtnueucZKeVg4srhmzbpAeb1KoN", script_payee);
         job_pack_tx(coind, templ->coinb2, 1 * 100000000, script_payee);
-         base58_decode("a1HwTdCmQV3NspP2QqCGpehoFpi8NY4Zg3", script_payee);
+        base58_decode("a1HwTdCmQV3NspP2QqCGpehoFpi8NY4Zg3", script_payee);
         job_pack_tx(coind, templ->coinb2, 3 * 100000000, script_payee);
-         base58_decode("a1kCCGddf5pMXSipLVD9hBG2MGGVNaJ15U", script_payee);
+        base58_decode("a1kCCGddf5pMXSipLVD9hBG2MGGVNaJ15U", script_payee);
         job_pack_tx(coind, templ->coinb2, 1 * 100000000, script_payee);
-         strcat(templ->coinb2, "00000000"); // locktime
+        strcat(templ->coinb2, "00000000"); // locktime
         coind->reward = (double)available/100000000*coind->reward_mul;
-         return;
+        return;
+    }
+	
+	else if(!strcmp(coind->symbol, "HXX")) //hardcoded everything
+	{
+        char script_payee[1024];
+        bool znode_masternode_enabled = json_get_bool(json_result, "xnode_payments_started");
+        if (znode_masternode_enabled == true) {
+            json_value* znode_masternode = json_get_object(json_result, "xnode");
+            const char *payee = json_get_string(znode_masternode, "payee");
+            json_int_t amount = json_get_int(znode_masternode, "amount");
+            if (payee && amount) {
+                //debuglog("bznode payee: %s\n", payee);
+                strcat(templ->coinb2, "06");
+                job_pack_tx(coind, templ->coinb2, available, NULL);
+                base58_decode(payee, script_payee);
+                job_pack_tx(coind, templ->coinb2, amount, script_payee);
+            }
+        } else {
+            strcat(templ->coinb2, "05");
+            job_pack_tx(coind, templ->coinb2, available, NULL);
+        }
+        base58_decode("HE7NSv3jevUAPjwsLGpoYSz9ftzV9S36Xq", script_payee);
+        job_pack_tx(coind, templ->coinb2, 0.1 * 100000000, script_payee);
+        base58_decode("HNdzbEtifr2nTd3VBvUWqJLc35ZFXr2EYo", script_payee);
+        job_pack_tx(coind, templ->coinb2, 0.1 * 100000000, script_payee);
+        base58_decode("HG1utYiVhkgBNz5ezrVpsjABxmMdVdcQe5", script_payee);
+        job_pack_tx(coind, templ->coinb2, 0.1 * 100000000, script_payee);
+        base58_decode("H94j1zMAbWwHWcEq8hUogAMALpVzj34M6Q", script_payee);
+        job_pack_tx(coind, templ->coinb2, 0.3 * 100000000, script_payee);
+        strcat(templ->coinb2, "00000000"); // locktime
+        coind->reward = (double)available/100000000*coind->reward_mul;
+        return;
     }
 
-	else if(strcmp("DCR", coind->rpcencoding) == 0) {
-		coind->reward_mul = 6;  // coinbase value is wrong, reward_mul should be 6
-		coind->charity_percent = 0;
-		coind->charity_amount = available;
-		available *= coind->reward_mul;
-		if (strlen(coind->charity_address) == 0 && !strcmp(coind->symbol, "DCR"))
-			sprintf(coind->charity_address, "Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx");
+	else if(!strcmp(coind->symbol, "BZX")) //hardcoded everything
+	{
+		char script_payee[1024];
+		bool znode_masternode_enabled = json_get_bool(json_result, "bznode_payments_started");
+		if (znode_masternode_enabled == true) {
+			json_value* znode_masternode = json_get_object(json_result, "bznode");
+			const char *payee = json_get_string(znode_masternode, "payee");
+			json_int_t amount = json_get_int(znode_masternode, "amount");
+			if (payee && amount) {
+				//debuglog("bznode payee: %s\n", payee);
+				strcat(templ->coinb2, "04");
+				job_pack_tx(coind, templ->coinb2, available, NULL);
+				base58_decode(payee, script_payee);
+				job_pack_tx(coind, templ->coinb2, amount, script_payee);
+			}
+		} else {
+			strcat(templ->coinb2, "03");
+			job_pack_tx(coind, templ->coinb2, available, NULL);
+		}
+		base58_decode("XWfdnGbXnBxeegrPJEvnYaNuwf6DXCruMX", script_payee);
+		job_pack_tx(coind, templ->coinb2, 6.75 * 100000000, script_payee);
+		base58_decode("XQ4WEZTFP83gVhhLBKavwopz7U84JucR8w", script_payee);
+		job_pack_tx(coind, templ->coinb2, 2.25 * 100000000, script_payee);
+		strcat(templ->coinb2, "00000000"); // locktime
+		coind->reward = (double)available/100000000*coind->reward_mul;
+		return;
 	}
-    else if(strcmp(coind->symbol, "GXX") == 0) {
-      char script_payee[1024];
-      bool xnode_masternode_enabled = json_get_bool(json_result, "xnode_payments_started");
-      if (xnode_masternode_enabled == true) {
-        json_value* xnode_masternode = json_get_object(json_result, "xnode");
-        const char *payee = json_get_string(xnode_masternode, "payee");
-        json_int_t amount = json_get_int(xnode_masternode, "amount");
-        if (payee && amount) {
-          //debuglog("xnode payee: %s\n", payee);
-          strcat(templ->coinb2, "04");
-          job_pack_tx(coind, templ->coinb2, available, NULL);
-          base58_decode(payee, script_payee);
-          job_pack_tx(coind, templ->coinb2, amount, script_payee);
-        }
-      } else {
-        strcat(templ->coinb2, "03");
-        job_pack_tx(coind, templ->coinb2, available, NULL);
-      }
-      base58_decode("HU9t1QEp5J8udekCqFUEajD5TeigPqtfDZ", script_payee);
-      job_pack_tx(coind, templ->coinb2, 2 * 100000000, script_payee);
-      base58_decode("HLFmojjH6qLBTh5EXtbY9j9v4BCkNpmt95", script_payee);
-      job_pack_tx(coind, templ->coinb2, 1.5 * 100000000, script_payee);
-      strcat(templ->coinb2, "00000000"); // locktime
-      coind->reward = (double)available/100000000*coind->reward_mul;
-      return;
-    }
-    ///////////////////////////////////////////////////////////////
-    //   Updated BitcoinZero BZX Masternode payments 12.04.2022  //
-    ///////////////////////////////////////////////////////////////
-        if (strcmp(coind->symbol, "BZX") == 0) {
-        char payees[2];
-        int npayees = 1;
-        char script_dests[2048] = { 0 };
-        char script_payee[128] = { 0 };
-        json_value* masternode = json_get_object(json_result, "masternode");
-        bool started = json_get_bool(json_result, "masternode_payments_started");
-            if (masternode && started) {
-                if (json_is_array(masternode)) {
-                    for(int i = 0; i < masternode->u.array.length; i++) {
-                        const char *payee = json_get_string(masternode->u.array.values[i], "payee");
-                        const char *script = json_get_string(masternode->u.array.values[i], "script");
-                        json_int_t amount = json_get_int(masternode->u.array.values[i], "amount");
-                        if (!amount) continue;
-                            if (script) {
-                                npayees++;
-                                available = amount;
-                                script_pack_tx(coind, script_dests, amount, script);
-                            }
-                            else if (payee) {
-                                npayees++;
-                                available = amount;
-                                base58_decode(payee, script_payee);
-                                job_pack_tx(coind, script_dests, amount, script_payee);
-                                //debuglog("%s masternode %s %u\n", coind->symbol, payee, amount);
-                            }
-                    }
-                } else {
-                    const char *payee = json_get_string(masternode, "payee");
-                    json_int_t amount = json_get_int(masternode, "amount");
-                    if (payee && amount) {
-                        npayees++;
-                        available = amount;
-                        base58_decode(payee, script_payee);
-                        job_pack_tx(coind, script_dests, amount, script_payee);
-                    }
-                }
-            }
-            sprintf(payees, "%02x", npayees);
-            strcat(templ->coinb2, payees);
-            strcat(templ->coinb2, script_dests);
-            job_pack_tx(coind, templ->coinb2, available, NULL);
-            strcat(templ->coinb2, "00000000"); // locktime
-            if(coinbase_payload && strlen(coinbase_payload) > 0) {
-                char coinbase_payload_size[38];
-                ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-                strcat(templ->coinb2, coinbase_payload_size);
-                strcat(templ->coinb2, coinbase_payload);
-            }
-            coind->reward = (double)available/100000000*coind->reward_mul;
-            return;
-        }
-	else if(strcmp(coind->symbol, "STAK") == 0) {
+
+	else if(!strcmp(coind->symbol, "STAK")) //hardcoded everything
+	{
 		char script_payee[512] = { 0 };
 		char payees[4];
 		int npayees = (templ->has_segwit_txs) ? 2 : 1;
@@ -1654,444 +529,8 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		coind->reward = (double)available / 100000000 * coind->reward_mul;
 		return;
 	}
-	else if(strcmp(coind->symbol, "TUX") == 0)  {
-		char script_payee[1024];
-		char charity_payee[256] = { 0 };
-		const char *payee = json_get_string(json_result, "donation_payee");
-		if(payee != NULL){
-			sprintf(coind->charity_address, "%s", payee);
-		} else {
-			sprintf(coind->charity_address, "%s", "");
-		}
 
-		if(strlen(coind->charity_address) > 0){
-			char script_payee[1024];
-			char charity_payee[256] = { 0 };
-			sprintf(charity_payee, "%s", coind->charity_address);
-			if (strlen(charity_payee) == 0)
-				stratumlog("ERROR %s has no charity_address set!\n", coind->name);
-
-			base58_decode(charity_payee, script_payee);
-
-			json_int_t charity_amount = json_get_int(json_result, "donation_amount");
-			coind->charity_amount = charity_amount;
-
-			if (templ->has_segwit_txs) {
-				strcat(templ->coinb2, "03"); // 3 outputs (nulldata + fees + miner)
-				strcat(templ->coinb2, commitment);
-			} else {
-				strcat(templ->coinb2, "02");
-			}
-			job_pack_tx(coind, templ->coinb2, available, NULL);
-
-			char echarity_amount[32];
-			encode_tx_value(echarity_amount, charity_amount);
-			strcat(templ->coinb2, echarity_amount);
-			char coinb2_part[1024] = { 0 };
-			char coinb2_len[3] = { 0 };
-			sprintf(coinb2_part, "a9%02x%s87", (unsigned int)(strlen(script_payee) >> 1) & 0xFF, script_payee);
-			sprintf(coinb2_len, "%02x", (unsigned int)(strlen(coinb2_part) >> 1) & 0xFF);
-			strcat(templ->coinb2, coinb2_len);
-			strcat(templ->coinb2, coinb2_part);
-			debuglog("pack tx %s\n", coinb2_part);
-			strcat(templ->coinb2, "00000000"); // locktime
-
-			coind->reward = (double)available/100000000*coind->reward_mul;
-			//debuglog("INFO %s block available %f, charity %f miner %f\n", coind->symbol,
-			//	(double) available/1e8, (double) charity_amount/1e8, coind->reward);
-			return;
-		}
-	}
-
-	bool founder_enabled = json_get_bool(json_result, "founder_payments_started");
-	json_value* founder = json_get_object(json_result, "founder");
-
-	if (!coind->hasmasternodes && founder_enabled && founder) {
-		char founder_payee[256] = { 0 };
-		char founder_script[1024] = { 0};
-		const char *payee = json_get_string(founder, "payee");
-		bool founder_use_p2sh = (strcmp(coind->symbol, "PGN") == 0) || (strcmp(coind->symbol, "RITO") == 0);
-		json_int_t amount = json_get_int(founder, "amount");
-		if(payee && amount) {
-			if (payee) snprintf(founder_payee, 255, "%s", payee);
-			if (strlen(founder_payee) == 0)
-				stratumlog("ERROR %s has no charity_address set!\n", coind->name);
-			base58_decode(founder_payee, founder_script);
-			available -= amount;
-
-			if (templ->has_segwit_txs) {
-				strcat(templ->coinb2, "03"); // 3 outputs (nulldata + fees + miner)
-				strcat(templ->coinb2, commitment);
-			} else {
-				strcat(templ->coinb2, "02");
-			}
-			job_pack_tx(coind, templ->coinb2, available, NULL);
-			if(founder_use_p2sh) {
-				p2sh_pack_tx(coind, templ->coinb2, amount, founder_script);
-			} else {
-				job_pack_tx(coind, templ->coinb2, amount, founder_script);
-			}
-			strcat(templ->coinb2, "00000000"); // locktime
-
-			coind->reward = (double)available/100000000*coind->reward_mul;
-			debuglog("%s founder address %s, amount %lld\n", coind->symbol,founder_payee, amount);
-			debuglog("%s founder script %s\n", coind->symbol,founder_script);
-			debuglog("%s scripts %s\n", coind->symbol, templ->coinb2);
-
-		return;
-		}
-	}
-	// 2 txs are required on these coins, one for foundation (dev fees)
-	if(coind->charity_percent && !coind->hasmasternodes)
-	{
-		char script_payee[1024];
-		char charity_payee[256] = { 0 };
-		const char *payee = json_get_string(json_result, "payee");
-		if (payee) snprintf(charity_payee, 255, "%s", payee);
-		else sprintf(charity_payee, "%s", coind->charity_address);
-		if (strlen(charity_payee) == 0)
-			stratumlog("ERROR %s has no charity_address set!\n", coind->name);
-
-		base58_decode(charity_payee, script_payee);
-
-		json_int_t charity_amount = json_get_int(json_result, "payee_amount");
-		if (charity_amount <= 0)
-			charity_amount = (available * coind->charity_percent) / 100;
-
-		available -= charity_amount;
-		coind->charity_amount = charity_amount;
-
-		if (templ->has_segwit_txs) {
-			strcat(templ->coinb2, "03"); // 3 outputs (nulldata + fees + miner)
-			strcat(templ->coinb2, commitment);
-		} else {
-			strcat(templ->coinb2, "02");
-		}
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		job_pack_tx(coind, templ->coinb2, charity_amount, script_payee);
-		strcat(templ->coinb2, "00000000"); // locktime
-
-		coind->reward = (double)available/100000000*coind->reward_mul;
-		//debuglog("INFO %s block available %f, charity %f miner %f\n", coind->symbol,
-		//	(double) available/1e8, (double) charity_amount/1e8, coind->reward);
-		return;
-	}
-
-	else if(coind->charity_amount && !strcmp("DCR", coind->rpcencoding))
-	{
-		stratumlog("ERROR %s should not use coinbase (getwork only)!\n", coind->symbol);
-		coind->reward = (double)available/100000000;
-		return;
-	}
-
-	//  add IFX
-	if (strcmp(coind->symbol, "IFX") == 0)
-{
-	char payees[4];
-	int npayees = 1;
-	char script_dests[4096] = { 0 };
-	//
-	json_value* founderreward = json_get_array(json_result, "founderreward");
-	if (founderreward)
-	{
-		const char *payee = json_get_string(founderreward, "founderpayee");
-		json_int_t amount = json_get_int(founderreward, "amount");
-		if (payee && amount)
-		{
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	json_value* masternode = json_get_object(json_result, "masternode");
-	bool masternode_enabled = json_get_bool(json_result, "masternode_payments_enforced");
-	if (masternode_enabled && masternode)
-	{
-		bool started = json_get_bool(json_result, "masternode_payments_started");
-		const char *payee = json_get_string(masternode, "payee");
-		json_int_t amount = json_get_int(masternode, "amount");
-		if (started && payee && amount) {
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	sprintf(payees, "%02x", npayees);
-	strcat(templ->coinb2, payees);
-	strcat(templ->coinb2, script_dests);
-	job_pack_tx(coind, templ->coinb2, available, NULL);
-	strcat(templ->coinb2, "00000000"); // locktime
-	coind->reward = (double)available / 100000000 * coind->reward_mul;
-	return;
-	}
-
-	//  add GTM
-	if (strcmp(coind->symbol, "GTM") == 0)
-{
-	char payees[4];
-	int npayees = 1;
-	char script_dests[4096] = { 0 };
-	//
-	json_value* founderreward = json_get_array(json_result, "founderreward");
-	if (founderreward)
-	{
-		const char *payee = json_get_string(founderreward, "founderpayee");
-		json_int_t amount = json_get_int(founderreward, "amount");
-		if (payee && amount)
-		{
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	json_value* masternode = json_get_object(json_result, "masternode");
-	bool masternode_enabled = json_get_bool(json_result, "masternode_payments_enforced");
-	if (masternode_enabled && masternode)
-	{
-		bool started = json_get_bool(json_result, "masternode_payments_started");
-		const char *payee = json_get_string(masternode, "payee");
-		json_int_t amount = json_get_int(masternode, "amount");
-		if (started && payee && amount) {
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	sprintf(payees, "%02x", npayees);
-	strcat(templ->coinb2, payees);
-	strcat(templ->coinb2, script_dests);
-	job_pack_tx(coind, templ->coinb2, available, NULL);
-	strcat(templ->coinb2, "00000000"); // locktime
-	coind->reward = (double)available / 100000000 * coind->reward_mul;
-	return;
-	}
-
-	//  add GWAY
-	if (strcmp(coind->symbol, "GWAY") == 0)
-{
-	char payees[4];
-	int npayees = 1;
-	char script_dests[4096] = { 0 };
-	//
-	json_value* founderreward = json_get_array(json_result, "founderreward");
-	if (founderreward)
-	{
-		const char *payee = json_get_string(founderreward, "founderpayee");
-		json_int_t amount = json_get_int(founderreward, "amount");
-		if (payee && amount)
-		{
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	json_value* masternode = json_get_object(json_result, "masternode");
-	bool masternode_enabled = json_get_bool(json_result, "masternode_payments_enforced");
-	if (masternode_enabled && masternode)
-	{
-		bool started = json_get_bool(json_result, "masternode_payments_started");
-		const char *payee = json_get_string(masternode, "payee");
-		json_int_t amount = json_get_int(masternode, "amount");
-		if (started && payee && amount) {
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	sprintf(payees, "%02x", npayees);
-	strcat(templ->coinb2, payees);
-	strcat(templ->coinb2, script_dests);
-	job_pack_tx(coind, templ->coinb2, available, NULL);
-	strcat(templ->coinb2, "00000000"); // locktime
-	coind->reward = (double)available / 100000000 * coind->reward_mul;
-	return;
-	}
-
-	if (strcmp(coind->symbol, "AGM") == 0)
-{
-	char payees[4];
-	int npayees = 1;
-	char script_dests[4096] = { 0 };
-	//
-	json_value* founderreward = json_get_array(json_result, "founderreward");
-	if (founderreward)
-	{
-		const char *payee = json_get_string(founderreward, "founderpayee");
-		json_int_t amount = json_get_int(founderreward, "amount");
-		if (payee && amount)
-		{
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	json_value* masternode = json_get_object(json_result, "masternode");
-	bool masternode_enabled = json_get_bool(json_result, "masternode_payments_enforced");
-	if (masternode_enabled && masternode)
-	{
-		bool started = json_get_bool(json_result, "masternode_payments_started");
-		const char *payee = json_get_string(masternode, "payee");
-		json_int_t amount = json_get_int(masternode, "amount");
-		if (started && payee && amount) {
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	sprintf(payees, "%02x", npayees);
-	strcat(templ->coinb2, payees);
-	strcat(templ->coinb2, script_dests);
-	job_pack_tx(coind, templ->coinb2, available, NULL);
-	strcat(templ->coinb2, "00000000"); // locktime
-	coind->reward = (double)available / 100000000 * coind->reward_mul;
-	return;
-	}
-
-		// BCRS Reband to ADOT
-	else if(strcmp(coind->symbol, "ADOT") == 0 )
-	{
-		char payees[4];
-		int npayees = 1;
-		char script_dests[4096] = { 0 };
-		char script_payee[128] = { 0 };
-		char founder_script_payee[128] = { 0 };
-					
- 		json_value* masternode = json_get_object(json_result, "masternode");
-		bool masternode_started = json_get_bool(json_result, "masternode_payments_started");
-		if (masternode_started && masternode)
-		{
-			if (json_is_array(masternode)) 
-			{
-				for(int i = 0; i < masternode->u.array.length; i++) 
-				{
-					const char *payee = json_get_string(masternode->u.array.values[i], "payee");
-					const char *script = json_get_string(masternode->u.array.values[i], "script");
-					json_int_t amount = json_get_int(masternode->u.array.values[i], "amount");
-					if (!amount) continue;
-					if (script) 
-					{
-						npayees++;
-						available -= amount;
-						script_pack_tx(coind, script_dests, amount, script);
-					} 
-					else if (payee) 
-					{
-						npayees++;
-						available -= amount;
-						base58_decode(payee, script_payee);
-						job_pack_tx(coind, script_dests, amount, script_payee);
-						//debuglog("%s masternode %s %u\n", coind->symbol, payee, amount);
-					}
-				}
-			} 
-			else 
-			{
-				const char *payee = json_get_string(masternode, "payee");
-				json_int_t amount = json_get_int(masternode, "amount");
-				if (payee && amount) 
-				{
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-			}
-		}
-	
-		json_value* fundreward = json_get_array(json_result, "fundreward");
-		if (fundreward)
-		{
-			const char *founder_payee = json_get_string(fundreward, "payee");
-			json_int_t founder_amount = json_get_int(fundreward, "amount");
-			if (founder_payee && founder_amount)
-			{
-				npayees++;
-				available -= founder_amount;
-				base58_decode(founder_payee, founder_script_payee);
-				job_pack_tx(coind, script_dests, founder_amount, founder_script_payee);
-			}
-		}
-	
-	 	sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) 
-		{
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
-		}
-
-		coind->reward = (double)available / 100000000 * coind->reward_mul;
-		return;
-	}
-	
-	//  add BMN
-	if (strcmp(coind->symbol, "BMN") == 0)
-{
-	char payees[4];
-	int npayees = 1;
-	char script_dests[4096] = { 0 };
-	//
-	json_value* founderreward = json_get_array(json_result, "founderreward");
-	if (founderreward)
-	{
-		const char *payee = json_get_string(founderreward, "founderpayee");
-		json_int_t amount = json_get_int(founderreward, "amount");
-		if (payee && amount)
-		{
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	json_value* masternode = json_get_object(json_result, "masternode");
-	bool masternode_enabled = json_get_bool(json_result, "masternode_payments_enforced");
-	if (masternode_enabled && masternode)
-	{
-		bool started = json_get_bool(json_result, "masternode_payments_started");
-		const char *payee = json_get_string(masternode, "payee");
-		json_int_t amount = json_get_int(masternode, "amount");
-		if (started && payee && amount) {
-			char script_payee[128] = { 0 };
-			npayees++;
-			available -= amount;
-			base58_decode(payee, script_payee);
-			job_pack_tx(coind, script_dests, amount, script_payee);
-		}
-	}
- 	sprintf(payees, "%02x", npayees);
-	strcat(templ->coinb2, payees);
-	strcat(templ->coinb2, script_dests);
-	job_pack_tx(coind, templ->coinb2, available, NULL);
-	strcat(templ->coinb2, "00000000"); // locktime
-	coind->reward = (double)available / 100000000 * coind->reward_mul;
-	return;
-	}
-
- //add GLT
-	else if(strcmp(coind->symbol, "GLT") == 0)
+	else if(!strcmp(coind->symbol, "GLT")) //multiple payee names
 	{
 		char script_dests[2048] = { 0 };
 		char script_payee[128] = { 0 };
@@ -2133,9 +572,8 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		return;
 	}
 
-	// Add DigitalNote[XDN]
-    if(strcmp(coind->symbol, "XDN") == 0) {
-
+    else if(!strcmp(coind->symbol, "XDN")) //hardcoded rewards
+	{
 		// make sure we pay both mn and devops
 		bool founder_enabled = json_get_bool(json_result, "founder_reward_enforced");
 		bool masternode_enabled = json_get_bool(json_result, "enforce_masternode_payments");
@@ -2175,433 +613,199 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 			return;
     }
 
-    if(strcmp(coind->symbol, "SIN") == 0)
-    {
-      int npayees = 1;
-      char payees[2];
-      char sinpayee[256] = {0};
-      char sinscript[1024] = {0};
-      char devpayee[256] = {0};
-      char devscript[1024] = {0};
-      const char *devpayaddr = json_get_string(json_result, "payee");
-      json_int_t devfee_amount = json_get_int(json_result, "payee_amount");
-      snprintf(devpayee, 255, "%s", devpayaddr);
-      base58_decode(devpayee, devscript);
-      npayees++;
+	//=================================================================================================================
+	//If allowed, start 'full auto' processing. Covers old and new masternodes, founder/charity and superblocks. Manual charity % from SQL is enabled.
+	//Successfully tested with: ROGU (smartnode+founder), VIVO (new MN), GBX (new MN), FTC (none), PXC (none)
+	//Should cover theese: SMLY, DYN, VGC(oldMN), RTM, WATC, BUTK, IDX, ADOT, ENT, ARC, SIN(oldMN). Also (with strstr): IFX, GTM, GWAY, AGM, BMN, CRW
 
-      available -= devfee_amount;
-      const char* mnpayaddrs[7] = {0};
-      json_value* masternodes = json_get_array(json_result, "masternode");
-      json_int_t mnamounts[7] = {0};
-      for(int i = 0; i < masternodes->u.array.length; i++) {
-      mnpayaddrs[i] = json_get_string(masternodes->u.array.values[i], "payee");
-      mnamounts[i] = json_get_int(masternodes->u.array.values[i], "amount");
-      available -= mnamounts[i];
-      npayees++;
-    }
+	string scriptName = "script";
+	string payeeName = "payee";
+	string amountName = "amount";
+	string payeeNameOld = "payee";
+	string amountNameOld = "payee_amount";
 
-      sprintf(payees, "%02x", npayees);
-      strcat(templ->coinb2, payees);
-      job_pack_tx(coind, templ->coinb2, available, NULL);
-      job_pack_tx(coind, templ->coinb2, devfee_amount, devscript);
-      for(int i = 0; i < masternodes->u.array.length; i++) {
-          snprintf(sinpayee, 255, "%s", mnpayaddrs[i]);
-          base58_decode(sinpayee, sinscript);
-          job_pack_tx(coind, templ->coinb2, mnamounts[i], sinscript);
-      }
-
-      strcat(templ->coinb2, "00000000");
-      coind->reward = (double)available/100000000;
-      return;
-  }
-
-	if(strcmp(coind->symbol, "BITC") == 0)
-	{
-		char *params = (char *)malloc(1024);
-			if (params) {
-			sprintf(params, "[\"%s\", %i]", coind->wallet, templ->height);
-			//std::cout << "Params:" << params << std::endl;
-			json_value *json = rpc_call(&coind->rpc, "createcoinbaseforaddress", params);
-			free(params);
-			if (json) {
-				json_value *json_result = json_get_object(json, "result");
-				if (json_result) {
-					sprintf(templ->coinb1, "%s", json_get_string(json_result, "coinbasepart1"));
-					templ->coinb1[strlen(templ->coinb1) - 16] = '\0';
-					sprintf(templ->coinb2, "%s", json_get_string(json_result, "coinbasepart2"));
-				}
-			}
-		}
-		return;
+	if (!strcmp(coind->symbol, "TUX")) {
+		payeeNameOld = "donation_payee";
+		amountNameOld = "donation_amount";
 	}
 
-	if(strcmp(coind->symbol, "XVC") == 0)
-	{
-		char charity_payee[256];
-		json_value* incentive = json_get_object(json_result, "incentive");
-		if (incentive) {
-			const char* payee = json_get_string(incentive, "address");
-			if (payee) snprintf(charity_payee, 255, "%s", payee);
-			else sprintf(charity_payee, "%s", coind->charity_address);
-
-			bool enforced = json_get_bool(incentive, "enforced");
-			json_int_t charity_amount = json_get_int(incentive, "amount");
-			if (enforced && charity_amount && strlen(charity_payee)) {
-				char script_payee[1024];
-				base58_decode(charity_payee, script_payee);
-
-				strcat(templ->coinb2, "02");
-				job_pack_tx(coind, templ->coinb2, available, NULL);
-				job_pack_tx(coind, templ->coinb2, charity_amount, script_payee);
-				strcat(templ->coinb2, "00000000"); // locktime
-
-				coind->charity_amount = charity_amount;
-				coind->reward = (double)available/100000000*coind->reward_mul;
-				//debuglog("XVC coinbase %ld (+%ld incentive to %s)\n",
-				//	(long) available, (long) charity_amount, charity_payee);
-				return;
-			}
-		}
+	if (!strcmp(coind->symbol, "XVC")) {
+		payeeName = "address";
 	}
 
-	// most recent masternodes rpc (DASH, SIB, MUE, DSR, GBX...)
-	if(coind->hasmasternodes && !coind->oldmasternodes)
+	struct pay
 	{
-		char script_dests[2048] = { 0 };
-		char script_payee[128] = { 0 };
-		char payees[4]; // addresses count
-		int npayees = (templ->has_segwit_txs) ? 2 : 1;
-		bool masternode_enabled = json_get_bool(json_result, "masternode_payments_enforced");
-		bool superblocks_enabled = json_get_bool(json_result, "superblocks_enabled");
-		json_value* superblock = json_get_array(json_result, "superblock");
-		json_value* masternode = json_get_object(json_result, "masternode");
-		if(!masternode && json_get_bool(json_result, "masternode_payments")) {
-			coind->oldmasternodes = true;
-			debuglog("%s is using old masternodes rpc keys\n", coind->symbol);
-			return;
-		}
-		if(coind->charity_percent) {
-      char charity_payee[256] = { 0 };
-    	const char *payee = json_get_string(json_result, "payee");
-      if (payee) snprintf(charity_payee, 255, "%s", payee);
-          else sprintf(charity_payee, "%s", coind->charity_address);
-      if (strlen(charity_payee) == 0)
-          stratumlog("ERROR %s has no charity_address set!\n", coind->name);
-          json_int_t charity_amount = (available * coind->charity_percent) / 100;
-          npayees++;
-          available -= charity_amount;
-          coind->charity_amount = charity_amount;
-          base58_decode(charity_payee, script_payee);
-          job_pack_tx(coind, script_dests, charity_amount, script_payee);
-      }
-		// smart contracts balance refund, same format as DASH superblocks
-		json_value* screfund = json_get_array(json_result, "screfund");
-		if(screfund && screfund->u.array.length) {
-			superblocks_enabled = true;
-			superblock = screfund;
-		}
-		if(superblocks_enabled && superblock) {
-			for(int i = 0; i < superblock->u.array.length; i++) {
-				const char *payee = json_get_string(superblock->u.array.values[i], "payee");
-				const char *script = json_get_string(superblock->u.array.values[i], "script");
-				json_int_t amount = json_get_int(superblock->u.array.values[i], "amount");
-				if (!amount) continue;
-				if (script) {
-					npayees++;
-					available -= amount;
-					script_pack_tx(coind, script_dests, amount, script);
-				} else if (payee) {
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					bool superblock_use_p2sh = (strcmp(coind->symbol, "MAC") == 0);
-					if(superblock_use_p2sh)
-						p2sh_pack_tx(coind, script_dests, amount, script_payee);
-					else
-						job_pack_tx(coind, script_dests, amount, script_payee);
-					//debuglog("%s superblock %s %u\n", coind->symbol, payee, amount);
+		const char *name;
+		const char *script;
+		json_int_t amount {0};
+		const char *payee;
+	};
+	pay paysOldMN;
+	paysOldMN.name = "masternode";
+	struct enabl {const char *name; bool sw;};
+	vector <pay> pays;	
+	vector <enabl> enables;
+	
+	//const char *coinbase_payload;
+	for (unsigned int i = 0; i < json_result->u.object.length; i++) {
+		/* if (!strcmp(json_result->u.object.values[i].name, "coinbase_payload")) {
+			coinbase_payload = json_string_value(json_result->u.object.values[i].value);
+			continue;
+		} */
+			
+		 //if (json_result->u.object.values[i].value->type == json_object and json_result->u.object.values[i].value->u.object.length > 0 and json_result->u.object.values[i].value->u.object.length < 4  ) {
+		if (json_result->u.object.values[i].value->type == json_object and (json_result->u.object.values[i].value->u.object.length == 3 or json_result->u.object.values[i].value->u.object.length == 2)) {
+			json_value* obj = json_result->u.object.values[i].value;
+			pay tmpPay;
+			for (unsigned int k = 0; k < obj->u.object.length; k++) {
+				//debuglog("");
+				//if (obj->u.object.values[k].value->type == json_string and !strcmp(obj->u.object.values[k].name, "payee")) {
+				if (obj->u.object.values[k].value->type == json_string and strstr(obj->u.object.values[k].name, payeeName.c_str())) {
+					tmpPay.payee = obj->u.object.values[k].value->u.string.ptr;
+					//tmpPay.payee = json_string_value(obj->u.object.values[k].value);
+					continue;
+				}
+				if (obj->u.object.values[k].value->type == json_string and strstr(obj->u.object.values[k].name, scriptName.c_str())) {
+					tmpPay.script = obj->u.object.values[k].value->u.string.ptr;
+					continue;
+				}
+				if (obj->u.object.values[k].value->type == json_integer and strstr(obj->u.object.values[k].name, amountName.c_str())) {
+					tmpPay.amount = obj->u.object.values[k].value->u.integer;
 				}
 			}
+			if (tmpPay.amount and (tmpPay.script or tmpPay.payee)) {
+				//debuglog("%s -- found pay in object ""%s"" sized %i! payee: %s, script %s, amount %ld\n", coind->symbol, json_result->u.object.values[i].name, obj->u.object.length, tmpPay.payee, tmpPay.script, tmpPay.amount);
+				tmpPay.name = json_result->u.object.values[i].name;
+				pays.push_back (tmpPay);
+			}
+			continue;
 		}
+		//json_int_t amount = json_get_int(masternode->u.array.values[i], "amount");
 
-		bool started = json_get_bool(json_result, "masternode_payments_started");
-		if (masternode_enabled && masternode && started) {
-			if (json_is_array(masternode)) {
-				for(int i = 0; i < masternode->u.array.length; i++) {
-					const char *payee = json_get_string(masternode->u.array.values[i], "payee");
-					const char *script = json_get_string(masternode->u.array.values[i], "script");
-					json_int_t amount = json_get_int(masternode->u.array.values[i], "amount");
-					if (!amount) continue;
-					if (script) {
-						npayees++;
-						available -= amount;
-						script_pack_tx(coind, script_dests, amount, script);
-						} else if (payee) {
-						npayees++;
-						available -= amount;
-						base58_decode(payee, script_payee);
-						bool masternode_use_p2sh = (strcmp(coind->symbol, "MAC") == 0);
-						if(masternode_use_p2sh)
-							p2sh_pack_tx(coind, script_dests, amount, script_payee);
-						else
-							job_pack_tx(coind, script_dests, amount, script_payee);
-						//debuglog("%s masternode %s %u\n", coind->symbol, payee, amount);
+		//"capabilities" "transactions" "mutable" "rules"
+		if (json_result->u.object.values[i].value->type == json_array and json_result->u.object.values[i].value->u.array.length > 0 \
+			and strcmp(json_result->u.object.values[i].name, "transactions") and strcmp(json_result->u.object.values[i].name, "capabilities") and strcmp(json_result->u.object.values[i].name, "mutable") and strcmp(json_result->u.object.values[i].name, "rules")) 
+		{
+			json_value* arr = json_result->u.object.values[i].value;
+			// debuglog("Coinbase -- %s arr0!\n", coind->symbol);
+
+			if (!arr) continue;
+			// debuglog("Coinbase -- %s arr 1! -- %s\n", coind->symbol, json_result->u.object.values[i].name);
+			for (unsigned int j = 0; j < arr->u.array.length; j++) {
+				if (arr->u.array.values[j]->type != json_object) continue;
+				//pay tmpPay; tmpPay.amount=1;
+				// debuglog("Coinbase -- %s arr 2!\n", coind->symbol);
+				json_value* obj = arr->u.array.values[j];
+				if (!obj or obj->u.object.length > 3 or obj->u.object.length < 2) continue;
+				pay tmpPay;
+				// debuglog("Coinbase -- %s arr 3!\n", coind->symbol);
+				for (unsigned int k = 0; k < obj->u.object.length; k++) {
+					if (obj->u.object.values[k].value->type == json_string and strstr(obj->u.object.values[k].name, payeeName.c_str())) {
+						tmpPay.payee = obj->u.object.values[k].value->u.string.ptr;
+						continue;
+					}
+					if (obj->u.object.values[k].value->type == json_string and strstr(obj->u.object.values[k].name, scriptName.c_str())) {
+						tmpPay.script = obj->u.object.values[k].value->u.string.ptr;
+						continue;
+					}
+					if (obj->u.object.values[k].value->type == json_integer and strstr(obj->u.object.values[k].name, amountName.c_str())) {
+						tmpPay.amount = obj->u.object.values[k].value->u.integer;
 					}
 				}
-			} else {
-				const char *payee = json_get_string(masternode, "payee");
-				json_int_t amount = json_get_int(masternode, "amount");
-				if (payee && amount) {
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					bool masternode_use_p2sh = (strcmp(coind->symbol, "MAC") == 0);
-					if(masternode_use_p2sh)
-						p2sh_pack_tx(coind, script_dests, amount, script_payee);
-					else
-						job_pack_tx(coind, script_dests, amount, script_payee);
+				if (tmpPay.amount and (tmpPay.script or tmpPay.payee)) {
+					//debuglog("%s -- found pay in array ""%s""! payee: %s, script %s, amount %ld\n", coind->symbol, json_result->u.object.values[i].name, tmpPay.payee, tmpPay.script, tmpPay.amount);
+					tmpPay.name = json_result->u.object.values[i].name;
+					pays.push_back (tmpPay);
 				}
 			}
-		}
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		if (templ->has_segwit_txs) strcat(templ->coinb2, commitment);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		if(coinbase_payload && strlen(coinbase_payload) > 0) {
-			char coinbase_payload_size[18];
-			ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload_size);
-			strcat(templ->coinb2, coinbase_payload);
+			continue;
 		}
 
-		coind->reward = (double)available/100000000*coind->reward_mul;
-		//debuglog("%s total %u available %u\n", coind->symbol, templ->value, available);
-		//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
-		return;
+		if (json_result->u.object.values[i].value->type == json_boolean) {
+			enabl tmpEnabl;
+			tmpEnabl.name = json_result->u.object.values[i].name;
+			tmpEnabl.sw = json_result->u.object.values[i].value->u.boolean;
+			enables.push_back(tmpEnabl);
+			continue;
+		}
+
+		if (json_result->u.object.values[i].value->type == json_string and json_result->u.object.values[i].name == payeeName.c_str()) {
+			paysOldMN.payee = json_result->u.object.values[i].value->u.string.ptr;
+			continue;
+		}
+		if (json_result->u.object.values[i].value->type == json_integer and json_result->u.object.values[i].name == amountNameOld.c_str()) {
+			paysOldMN.amount = json_result->u.object.values[i].value->u.integer;
+		}
 	}
 
-	else if(strcmp(coind->symbol, "ARC") == 0)
-	{
-		char script_dests[2048] = { 0 };
-		char script_payee[128] = { 0 };
-		char payees[4];
-		int npayees = 1;
-		bool masternode_enabled = json_get_bool(json_result, "goldminenode_payments_enforced");
-		bool superblocks_enabled = json_get_bool(json_result, "superblocks_enabled");
-		json_value* superblock = json_get_array(json_result, "superblock");
-		json_value* masternode = json_get_object(json_result, "goldminenode");
-		if(superblocks_enabled && superblock) {
-			for(int i = 0; i < superblock->u.array.length; i++) {
-				const char *payee = json_get_string(superblock->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(superblock->u.array.values[i], "amount");
-				if (payee && amount) {
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-					//debuglog("%s superblock %s %u\n", coind->symbol, payee, amount);
-				}
-			}
-		}
-		if (masternode_enabled && masternode) {
-			const char *payee = json_get_string(masternode, "payee");
-			json_int_t amount = json_get_int(masternode, "amount");
-			if (payee && amount) {
+	if (paysOldMN.amount and (paysOldMN.script or paysOldMN.payee))
+		pays.push_back(paysOldMN);
+
+	if (coind->charity_percent > 0 and strlen(coind->charity_address) > 10) {
+		pay tmpPay;
+		tmpPay.amount = (available * coind->charity_percent) / 100;
+		tmpPay.payee = coind->charity_address;
+		pays.push_back(tmpPay);
+	}
+
+	char payees[4]; // addresses count
+	int npayees = (templ->has_segwit_txs) ? 2 : 1;
+	char script_dests[4096] = { 0 };
+
+	if (!pays.empty()) {
+		for (const auto & p : pays) {
+			if (p.script) {
 				npayees++;
-				available -= amount;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
+				available -= p.amount;
+				script_pack_tx(coind, script_dests, p.amount, p.script);
 			}
-		}
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		coind->reward = (double)available/100000000*coind->reward_mul;
-		//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
-		return;
-	}
-
-	else if(strcmp(coind->symbol, "ENT") == 0)
-	{
-		char script_dests[2048] = { 0 };
-		char script_payee[128] = { 0 };
-		char payees[4];
-		int npayees = 1;
-		bool masternode_enabled = json_get_bool(json_result, "eternitynode_payments_enforced");
-		bool superblocks_enabled = json_get_bool(json_result, "superblocks_enabled");
-		json_value* superblock = json_get_array(json_result, "superblock");
-		json_value* masternode = json_get_object(json_result, "eternitynode");
-		if(superblocks_enabled && superblock) {
-			for(int i = 0; i < superblock->u.array.length; i++) {
-				const char *payee = json_get_string(superblock->u.array.values[i], "payee");
-				json_int_t amount = json_get_int(superblock->u.array.values[i], "amount");
-				if (payee && amount) {
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-					//debuglog("%s superblock %s %u\n", coind->symbol, payee, amount);
-				}
-			}
-		}
-		if (masternode_enabled && masternode) {
-			const char *payee = json_get_string(masternode, "payee");
-			json_int_t amount = json_get_int(masternode, "amount");
-			if (payee && amount) {
+			else if (p.payee) {
+				char script_payee[128] = { 0 };
 				npayees++;
-				available -= amount;
-				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
+				available -= p.amount;
+				base58_decode(p.payee, script_payee);
+				job_pack_tx(coind, script_dests, p.amount, script_payee);
 			}
 		}
-		sprintf(payees, "%02x", npayees);
-		strcat(templ->coinb2, payees);
-		strcat(templ->coinb2, script_dests);
-		job_pack_tx(coind, templ->coinb2, available, NULL);
-		strcat(templ->coinb2, "00000000"); // locktime
-		coind->reward = (double)available/100000000*coind->reward_mul;
-		//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
-		return;
 	}
 
-
-	else if(coind->hasmasternodes && coind->oldmasternodes) /* OLD DASH style */
-	{
+	/* if (coind->charity_percent > 0 and strlen(coind->charity_address) > 10) {
 		char charity_payee[256] = { 0 };
-		const char *payee = json_get_string(json_result, "payee");
-		if (payee) snprintf(charity_payee, 255, "%s", payee);
+		char script_payee[128] = { 0 };
+		snprintf(charity_payee, 255, "%s", coind->charity_address);
+		json_int_t charity_amount = (available * coind->charity_percent) / 100;
+		npayees++;
+		available -= charity_amount;
+		coind->charity_amount = charity_amount;
+		base58_decode(charity_payee, script_payee);
+		job_pack_tx(coind, script_dests, charity_amount, script_payee);
+	} */
 
-		json_int_t charity_amount = json_get_int(json_result, "payee_amount");
-		bool charity_payments = json_get_bool(json_result, "masternode_payments");
-		bool charity_enforce = json_get_bool(json_result, "enforce_masternode_payments");
-
-		if(strcmp(coind->symbol, "CRW") == 0)
-		{
-			char script_dests[2048] = { 0 };
-			char script_payee[128] = { 0 };
-			char payees[4];
-			int npayees = 1;
-			bool masternodes_enabled = json_get_bool(json_result, "enforce_masternode_payments");
-			bool systemnodes_enabled = json_get_bool(json_result, "enforce_systemnode_payments");
-			bool systemnodes = json_get_bool(json_result, "systemnodes");
-			bool masternodes = json_get_bool(json_result, "masternodes");
-			if(systemnodes_enabled && systemnodes) {
-				const char *payeeSN = json_get_string(json_result, "payeeSN");
-				json_int_t payeeSN_amount = json_get_int(json_result, "payeeSN_amount");
-				if (payeeSN && payeeSN_amount) {
-					npayees++;
-					available -= payeeSN_amount;
-					base58_decode(payeeSN, script_payee);
-					job_pack_tx(coind, script_dests, payeeSN_amount, script_payee);
-					//debuglog("%s systemnode %s %u\n", coind->symbol, payeeSN, payeeSN_amount);
-				}
-			}
-			if (masternodes_enabled && masternodes) {
-				const char *payee = json_get_string(json_result, "payee");
-				json_int_t amount = json_get_int(json_result, "amount");
-				if (payee && amount) {
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-			}
-			sprintf(payees, "%02x", npayees);
-			strcat(templ->coinb2, payees);
-			strcat(templ->coinb2, script_dests);
-			job_pack_tx(coind, templ->coinb2, available, NULL);
-			strcat(templ->coinb2, "00000000"); // locktime
-			coind->reward = (double)available/100000000*coind->reward_mul;
-			//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
-			return;
-		}
-
-		if(charity_payments && charity_enforce)
-		{
-			char script_payee[256] = { 0 };
-			base58_decode(charity_payee, script_payee);
-
-			if (templ->has_segwit_txs) {
-				strcat(templ->coinb2, "03"); // 3 outputs (nulldata + node + miner)
-				strcat(templ->coinb2, commitment);
-			} else {
-				strcat(templ->coinb2, "02"); // 2 outputs
-			}
-
-			job_pack_tx(coind, templ->coinb2, charity_amount, script_payee);
-			available -= charity_amount;
-
-		} else {
-			strcat(templ->coinb2, "01");
-		}
-	}
-
-	else if (templ->has_segwit_txs) {
-		strcat(templ->coinb2, "02");
-		strcat(templ->coinb2, commitment);
-	} else {
-		strcat(templ->coinb2, "01");
-	}
-
+	sprintf(payees, "%02x", npayees);
+	strcat(templ->coinb2, payees);
+	if (templ->has_segwit_txs) strcat(templ->coinb2, commitment);
+	if (!pays.empty()) strcat(templ->coinb2, script_dests);
 	if (templ->is_p2wpkh) {
 		strcpy(templ->coinb2_p2wpkh, templ->coinb2);
 		job_pack_tx(coind, templ->coinb2_p2wpkh, available, NULL, (coind->p2wpkh));
 	}
 
 	job_pack_tx(coind, templ->coinb2, available, NULL);
+	if(strcmp(coind->symbol, "DEM") == 0){if(coind->txmessage){strcat(templ->coinb2, "00");}} //fixes eMark. Also GIO-GravioCoin and FLO-FlorinCoin, but they are pos/dead
 
-	//if(coind->txmessage)
-	//	strcat(templ->coinb2, "00");
-	if(strcmp(coind->symbol, "DEM") == 0){if(coind->txmessage){strcat(templ->coinb2, "00");}} //fixes eMark.
-  if(strcmp(coind->symbol, "FLO") == 0){if(coind->txmessage){strcat(templ->coinb2, "00");}} //fixes FlorinCoin
-	if(strcmp(coind->symbol, "GIO") == 0){if(coind->txmessage){strcat(templ->coinb2, "00");}} //fixes GravioCoin
 	strcat(templ->coinb2, "00000000"); // locktime
-	if (templ->is_p2wpkh) {
-		strcat(templ->coinb2_p2wpkh, "00000000"); // locktime
+	if(!pays.empty() and coinbase_payload and strlen(coinbase_payload) > 0) {
+		char coinbase_payload_size[18];
+		ser_compactsize((unsigned int)(strlen(coinbase_payload) >> 1), coinbase_payload_size);
+		strcat(templ->coinb2, coinbase_payload_size);
+		strcat(templ->coinb2, coinbase_payload);
 	}
+	//debuglog("Coinbase -- %s proc 10!\n", coind->symbol);
 
 	coind->reward = (double)available/100000000*coind->reward_mul;
-//	debuglog("coinbase %f\n", coind->reward);
 
+//	debuglog("coinbase %f\n", coind->reward);
 //	debuglog("coinbase %s: version %s, nbits %s, time %s\n", coind->symbol, templ->version, templ->nbits, templ->ntime);
 //	debuglog("coinb1 %s\n", templ->coinb1);
 //	debuglog("coinb2 %s\n", templ->coinb2);
-
-	if(!strcmp(g_stratum_algo,"neoscrypt-xaya")) {
-
-       	sprintf(templ->xaya_coinbase, "%s%s", templ->coinb1, templ->coinb2);
-
-		int coinbase_len = strlen(templ->xaya_coinbase);
-
-		unsigned char coinbase_bin[1024];
-		memset(coinbase_bin, 0, 1024);
-		binlify(coinbase_bin, templ->xaya_coinbase);
-
-		char doublehash[128];
-		memset(doublehash, 0, 128);
-
-		sha256_double_hash_hex((char *)coinbase_bin, doublehash, coinbase_len/2);
-
-		string merkleroot = merkle_with_first(templ->txsteps, doublehash);
-
-		ser_string_be(merkleroot.c_str(), templ->xaya_merkleroothash, 8);
-
-		char prevhash[128];
-		memset(prevhash, 0, 128);
-
-		string_be(templ->prevhash_hex, prevhash);
-		ser_string_be(prevhash, templ->prevhash_be, 8);
-
-		char xaya_header[1024];
-		memset(xaya_header, 0, 1024);
-
-		sprintf(xaya_header, "%s%s%s%s", templ->version, templ->prevhash_be, templ->xaya_merkleroothash, templ->ntime);
-
-		ser_string_be(xaya_header, templ->xaya_header, 20);
-		strcat(templ->xaya_header, "0000");
-	}
 }


### PR DESCRIPTION
A dirty re-implementation of mining wallet address autodetection. Fixes the need to paste pool address in web interface and creates wallet if needed.

Future work:
.coind_validate_address.getaddressinfo doesn't
need to be so picky.
.(another dirty) suppress rpc errors on older address calls.
.(the correct way) get a list of supported calls
via 'help' rpc.